### PR TITLE
Fix grammar in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,8 +227,8 @@ var TodoListApp = Flux.createDispatcher({
 
 ## Action Creators
 
-Action creators are the main controller of the app. **They are simply objects** that
-manages everything. It allows you to compose data and logic.
+Action creators are the main controllers of the app. **They are simply objects** that
+manage everything. They allow you to compose data and logic.
 
 ```javascript
 var TodoActionCreator = {


### PR DESCRIPTION
This change makes "controller" plural so that it agrees with the plural subject "action creators."  Because this plural form continued into the second sentence with "They are simply objects..." I also changed "manages" to the plural form. Likewise, in the third sentence, I changed "It allows" into "They allow" so that these three sentences are all consistent grammatically and agree with the plural form of the subject "action creators". Nothing else is changed.
