### PR TITLE
fix storeName reference

### DIFF
--- a/src/delorean.js
+++ b/src/delorean.js
@@ -198,7 +198,7 @@
     // After the component mounted, listen changes of the related stores
       componentDidMount: function () {
         var self = this, store, __changeHandler;
-        __changeHandler = function (store) {
+        __changeHandler = function (store, storeName) {
           return function () {
             var state;
             // call the components `storeDidChanged` method
@@ -216,7 +216,7 @@
         for (var storeName in this.stores) {
           if (__hasOwn(this.stores, storeName)) {
             store = this.stores[storeName];
-            store.onChange(__changeHandler(store));
+            store.onChange(__changeHandler(store, storeName));
           }
         }
       },


### PR DESCRIPTION
Hey Fatih,

I had a problem with using `@state.stores` shortcuts for multiple stores.
