### PR TITLE
Switched react mixin to use setState instead of forceUpdate

### DIFF
--- a/src/delorean.js
+++ b/src/delorean.js
@@ -252,7 +252,7 @@
       
         // Set state.stores for all present stores with a setState method defined
         for (var storeName in this.stores) {
-          if (_hasOwn(this.stores, storeName)) {
+          if (__hasOwn(this.stores, storeName)) {
             if (this.stores[storeName]
             &&  this.stores[storeName].store
             &&  this.stores[storeName].store.getState) {


### PR DESCRIPTION
from the React docs..

> NEVER mutate this.state directly, as calling setState() afterwards may replace the mutation you made. Treat this.state as if it were immutable.

This was bugging me a bit, let me know if you see any issues with my implementation. I suppose this is slightly less efficient, as every store's `getState` method will be called on each change event, but it would take many very large stores to create any noticeable performance hit.

Another solution would be to put each `storeName` as a key directly on `state`, but this of course creates a higher probably of a name conflict with a `state` the developer has applied to the view themselves.   
