### PR TITLE
Added isMounted check and component event cleanup

### DIFF
--- a/src/delorean.js
+++ b/src/delorean.js
@@ -222,13 +222,23 @@
               self.storeDidChange.apply(self, args);
             }
             // change state
-            self.setState(self.getStoreStates());
+            if (self.isMounted()) { 
+              self.setState(self.getStoreStates()); 
+            }
           };
         };
         for (var storeName in this.stores) {
           if (__hasOwn(this.stores, storeName)) {
             store = this.stores[storeName];
             store.onChange(__changeHandler(store, storeName));
+          }
+        }
+      },
+      componentWillUnmount: function() {
+        for (var storeName in this.stores) {
+          if (__hasOwn(this.stores, storeName)) {
+            var store = this.stores[storeName];
+            store.listener.removeAllListeners('change')
           }
         }
       },


### PR DESCRIPTION
This solves 2 issues...

The first was introduced in my last PR, as you cannot `setState` on an unmounted component. I have fixed this by adding an isMounted check before calling `setState` on a store change event. This should not be a problem, as should the component mount again, `getInitialState` will take care of retrieving the latest data from the stores.

The second was an existing [issue](https://github.com/deloreanjs/delorean/issues/20) where components were not cleaning up after themselves when unmounting. Node's `eventEmitter` was complaining about a memory leak in cases where a component mounts and unmounts a number of times. (ie the change event handler was being applied repeatedly without ever being removed).
