### PR TITLE
fix scheme properties that are set to null

### DIFF
--- a/src/delorean.js
+++ b/src/delorean.js
@@ -255,12 +255,12 @@
         formattedScheme[keyName] = {default: null};
 
         /* {key: 'value'} will be {key: {default: 'value'}} */
-        defaultValue = (typeof definition === 'object') ?
+        defaultValue = (definition && typeof definition === 'object') ?
                         definition.default : definition;
         formattedScheme[keyName].default = defaultValue;
 
         /* {key: function () {}} will be {key: {calculate: function () {}}} */
-        if (typeof definition.calculate === 'function') {
+        if (definition && typeof definition.calculate === 'function') {
           calculatedValue = definition.calculate;
         } else if (typeof definition === 'function') {
           calculatedValue = definition;


### PR DESCRIPTION
delorean throws if having a scheme property that defaults to `null`, e.g.,

``` js
Flux.createStore({
  scheme: {
    prop: null
  }
})
```

because `typeof null === 'object'`.

This PR fixes this issue by checking if `definition` is set before checking if its an object.
