### PR TITLE
set component state before calling storeDidChange

### DIFF
--- a/src/delorean.js
+++ b/src/delorean.js
@@ -455,14 +455,14 @@
         function __changeHandler(store, storeName) {
           return function () {
             var state, args;
+            /* If the component is mounted, change state. */
+            if (self.isMounted()) {
+              self.setState(self.getStoreStates());
+            }
             // When something changes it calls the components `storeDidChanged` method if exists.
             if (self.storeDidChange) {
               args = [storeName].concat(Array.prototype.slice.call(arguments, 0));
               self.storeDidChange.apply(self, args);
-            }
-            /* If the component is mounted, change state. */
-            if (self.isMounted()) {
-              self.setState(self.getStoreStates());
             }
           };
         }


### PR DESCRIPTION
occasionally, you need to react to store data changing with something other than a component rendering. For these cases there is the `storeDidChange` method. The problem is, when this method fires, the component's `state`has not yet been updated, which is a problem if your `storeDidChange` method needs access to the new data on the store. This fixes that issue by setting the component's `state` before calling the `storeDidChange` method.
