### PR TITLE
Scheme Improvements

### DIFF
--- a/test/spec/core/fluxSpec.js
+++ b/test/spec/core/fluxSpec.js
@@ -3,6 +3,7 @@ describe('Flux', function () {
   var initializeSpy = jasmine.createSpy('construction');
   var listenerSpy = jasmine.createSpy('change');
   var listenerSpy2 = jasmine.createSpy('change');
+  var calculateSpy = jasmine.createSpy('calculate');
 
   var MyAppStore = DeLorean.Flux.createStore({
     list: [],
@@ -100,31 +101,88 @@ describe('Flux', function () {
 
   MyStoreWithScheme = DeLorean.Flux.createStore({
     scheme: {
-      x: 'hello',
-      y: 'world',
-      z: function () {
-        return this.x + ', ' + this.y;
+      greeting: 'hello',
+      place: {
+        default: 'world'
       },
-      t: {
-        default: 'def',
+      otherPlace: 'outerspace',
+      greetPlace: {
+        deps: ['greeting', 'place'],
+        default: 'hey',
         calculate: function (value) {
-          return value.toUpperCase() + ' ' + this.z;
+          return value.toUpperCase() + ' ' + this.greeting + ', ' + this.place;
+        }
+      },
+      parsedValue: function (value) {
+        return {
+          a: value.b,
+          b: value.a
+        }
+      },
+      randomProp: 'random',
+      anotherCalculated: {
+        deps: ['randomProp'],
+        default: null,
+        calculate: calculateSpy
+      },
+      dependentOnCalculated: {
+        deps: ['greetPlace'],
+        calculate: function () {
+          return this.greetPlace
         }
       }
     }
   });
-
   var myStoreWithScheme = new MyStoreWithScheme();
+  describe('scheme', function () {
+    it('should cause default and calculated scheme properties to be created on instantiation', function () {
+      expect(myStoreWithScheme.store.greeting).toBe('hello');
+      expect(myStoreWithScheme.store.place).toBe('world');
+      expect(myStoreWithScheme.store.greetPlace).toBe('HEY hello, world');
+    });
 
-  it('should be work with schemes', function () {
-    expect(myStoreWithScheme.store.z).toBe('hello, world');
-    myStoreWithScheme.set('y', 'moon');
-    expect(myStoreWithScheme.store.z).toBe('hello, moon');
-    myStoreWithScheme.set('x', 'salut');
-    expect(myStoreWithScheme.store.z).toBe('salut, moon');
-    expect(myStoreWithScheme.store.t).toBe('DEF salut, moon');
-    myStoreWithScheme.set('t', 'hey');
-    expect(myStoreWithScheme.store.t).toBe('HEY salut, moon');
+    it('should re-calculate scheme properties with #calculate and deps defined', function () {
+      myStoreWithScheme.set('greeting', 'goodbye');
+      expect(myStoreWithScheme.store.greetPlace).toBe('HEY goodbye, world');
+    });
+
+    it('should set scheme set scheme properties that are functions to the return value', function () {
+      var input = {
+        a: 'a',
+        b: 'b'
+      }
+      myStoreWithScheme.set('parsedValue', input);
+      expect(myStoreWithScheme.store.parsedValue.a).toBe(input.b);
+    });
+
+    it('should be able to accept an object when setting scheme', function () {
+      myStoreWithScheme.set({
+        greeting: 'aloha',
+        place: 'Hawaii'
+      });
+      expect(myStoreWithScheme.store.greeting).toBe('aloha');
+      expect(myStoreWithScheme.store.place).toBe('Hawaii');
+      expect(myStoreWithScheme.store.greetPlace).toBe('HEY aloha, Hawaii');
+    });
+
+    it('should call calculate only in instantiation and when a dependency is set', function () {
+      expect(calculateSpy.calls.length).toBe(1) // should have been called once on intantiation
+      myStoreWithScheme.set('otherPlace', 'hey');
+      expect(calculateSpy.calls.length).toBe(1) // should not have been called again, because otherPlace is not a dep
+    });
+
+    it('should allow setting calculated properties directly', function () {
+      myStoreWithScheme.set('greetPlace', 'Ahoy');
+      expect(myStoreWithScheme.store.greetPlace).toBe('AHOY aloha, Hawaii');
+    });
+
+    it('should allow a calculated property to be dependent on another calculated property', function () {
+      myStoreWithScheme.set({
+        greeting: 'hola',
+        place: 'Spain'
+      });
+      expect(myStoreWithScheme.store.dependentOnCalculated).toBe('AHOY hola, Spain');
+    });
   });
 
 });


### PR DESCRIPTION
fixes this [issue](https://github.com/deloreanjs/delorean/issues/41)

This enhancement is focused on getting `scheme` to scale. Ultimately, it is not practical to recalculate every `scheme` property on every `set` call. This allows developers to define `scheme` dependencies, which will allow delorean to only update calculated properties that actually need updating. Another important enhancement here is the ability to pass an object to `set`. This will allow developers to pass an entire server response rather than having to set each property individually.

Added:
- ability to pass an object of key/value pairs to `set`
- require developer to define a `deps` array on calculated properties to allow for efficient recalculations (ie `calculate` only runs when one of the `deps` is `set` or calculated)
- added many `scheme` tests to cover new and existing `scheme` functionality
- updated docs to reflect changes

see more in the updated [store docs](https://github.com/deloreanjs/delorean/blob/scheme-deps/docs/stores.md#advanced-data-structure-with-scheme)
