### PR TITLE
key fix for applying initial component state from scheme

### DIFF
--- a/src/delorean.js
+++ b/src/delorean.js
@@ -589,13 +589,14 @@
         /* Set `state.stores` for all present stores with a `setState` method defined. */
         for (var storeName in this.__watchStores) {
           if (__hasOwn(this.stores, storeName)) {
+            state.stores[storeName] = {}
             store = this.__watchStores[storeName].store;
             if (store && store.getState) {
               state.stores[storeName] = store.getState();
             } else if (typeof store.scheme === 'object') {
               var scheme = store.scheme;
               for (var keyName in scheme) {
-                state.stores[storeName] = store[keyName];
+                state.stores[storeName][keyName] = store[keyName];
               }
             }
           }


### PR DESCRIPTION
initial state from scheme, when `getState` is not defined, was broken. This fixes it.
