### PR TITLE
Clone scheme defaults to preserve them for later use

### DIFF
--- a/src/delorean.js
+++ b/src/delorean.js
@@ -44,13 +44,13 @@
     return view.props.dispatcher;
   }
 
-  // `__clone` creates a copy of an object.
+  // `__clone` creates a deep copy of an object.
   function __clone(obj) {
     if (null == obj || "object" != typeof obj) return obj;
     var copy = obj.constructor();
     for (var attr in obj) {
       if (__hasOwn(obj, attr)) {
-        copy[attr] = obj[attr];
+        copy[attr] = __clone(obj[attr]);
       }
     }
     return copy;
@@ -298,7 +298,7 @@
 
         /* {key: 'value'} will be {key: {default: 'value'}} */
         defaultValue = (definition && typeof definition === 'object') ?
-                        definition.default : definition;
+                        __clone(definition.default) : definition;
         formattedScheme[keyName].default = defaultValue;
 
         /* {key: function () {}} will be {key: {calculate: function () {}}} */


### PR DESCRIPTION
This simply uses the new `__clone` method to copy the defaults object while setting `scheme` attributes. This preserves the `default` value when it is an object, and allows it to be reused later to reset the scheme attribute to its default, eg..

``` javascript
this.set({
   mySchemeAttribute: this.scheme.mySchemeAttribute.default
});
```

Currently, the above would does nothing as `this.mySchemeAttribute` and `this.scheme.mySchemeAttribute.default` reference the same object in memory. This does not affect scheme  defaults that are not objects, as `__clone` returns the the passed argument for non-object types.

I also updated the `__clone` helper function to perform a deep clone. 
