### PR TITLE
Correction for previous preserving default PR

### DIFF
--- a/src/delorean.js
+++ b/src/delorean.js
@@ -298,7 +298,7 @@
 
         /* {key: 'value'} will be {key: {default: 'value'}} */
         defaultValue = (definition && typeof definition === 'object') ?
-                        __clone(definition.default) : definition;
+                        definition.default : definition;
         formattedScheme[keyName].default = defaultValue;
 
         /* {key: function () {}} will be {key: {calculate: function () {}}} */
@@ -333,7 +333,7 @@
         /* Set the defaults first */
         for (keyName in scheme) {
           definition = scheme[keyName];
-          this.store[keyName] = definition.default;
+          this.store[keyName] = __clone(definition.default);
         }
 
         /* Set the calculations */

--- a/test/spec/core/fluxSpec.js
+++ b/test/spec/core/fluxSpec.js
@@ -130,6 +130,11 @@ describe('Flux', function () {
         calculate: function () {
           return this.greetPlace;
         }
+      },
+      objectDefault: {
+        default: {
+          name: 'Test default objects get cloned'
+        }
       }
     }
   });
@@ -139,6 +144,10 @@ describe('Flux', function () {
       expect(myStoreWithScheme.store.greeting).toBe('hello');
       expect(myStoreWithScheme.store.place).toBe('world');
       expect(myStoreWithScheme.store.greetPlace).toBe('HEY hello, world');
+    });
+
+    it('should clone defaults that are objects, rather than applying them direclty', function () {
+      expect(myStoreWithScheme.store.scheme.objectDefault.default).not.toBe(myStoreWithScheme.store.objectDefault);
     });
 
     it('should re-calculate scheme properties with #calculate and deps defined', function () {


### PR DESCRIPTION
it seems I miscalculated where to put the defaults clone in my previous commit. This corrects it by moving the `__clone` call from `formatScheme` to `buildScheme`.

Also added a test for this.
