### PR TITLE
add dispatcher's rejection on rollback event

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "karma": "^0.12.22",
     "karma-chrome-launcher": "^0.1.4",
     "karma-coverage": "^0.2.6",
-    "karma-jasmine": "^0.1.5",
+    "karma-jasmine": "~0.2.0",
     "karma-phantomjs-launcher": "^0.1.4"
   },
   "dependencies": {

--- a/src/delorean.js
+++ b/src/delorean.js
@@ -160,6 +160,7 @@
           // you can change it using `DeLorean.Flux.define('Promise', AnotherPromise)`
           return new DeLorean.Promise(function (resolve, reject) {
             store.listener.once('change', resolve);
+            store.listener.once('rollback', reject);
           });
         }
 


### PR DESCRIPTION
Sometimes we need to know if action was failed and emitRollback was raised. But current implementation of `dispatch` method supports only resolvation. This PR brings promise rejection on rollback emission.